### PR TITLE
Workaround issue where IDvdInfo2 interface is no longer valid

### DIFF
--- a/MediaBrowser.Theater.DirectShow/Enums.cs
+++ b/MediaBrowser.Theater.DirectShow/Enums.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MediaBrowser.Theater.DirectShow
+{
+    internal enum DvdMenuMode
+    {
+        No, 
+        Buttons, 
+        Still
+    }
+}

--- a/MediaBrowser.Theater.DirectShow/MediaBrowser.Theater.DirectShow.csproj
+++ b/MediaBrowser.Theater.DirectShow/MediaBrowser.Theater.DirectShow.csproj
@@ -79,6 +79,7 @@
     <Compile Include="CustomCursor.cs" />
     <Compile Include="DirectShowPlayer.cs" />
     <Compile Include="Configuration\ConfigurationPageFactory.cs" />
+    <Compile Include="Enums.cs" />
     <Compile Include="Imports.cs" />
     <Compile Include="InternalDirectShowPlayer.cs" />
     <Compile Include="MadvrInterface.cs" />

--- a/MediaBrowser.Theater.Interfaces/Presentation/IHiddenWindow.cs
+++ b/MediaBrowser.Theater.Interfaces/Presentation/IHiddenWindow.cs
@@ -10,6 +10,8 @@ namespace MediaBrowser.Theater.Interfaces.Presentation
     public interface IHiddenWindow
     {
         event EventHandler SizeChanged;
+        event KeyEventHandler KeyDown;
+        event MouseEventHandler MouseClick;
 
         /// <summary>
         /// Gets the windows forms host.
@@ -20,5 +22,6 @@ namespace MediaBrowser.Theater.Interfaces.Presentation
         Size ContentPixelSize { get; }
 
         Action OnWMGRAPHNOTIFY { get; set; }
+        Action OnDVDEVENT { get; set; }
     }
 }

--- a/MediaBrowser.UI.sln
+++ b/MediaBrowser.UI.sln
@@ -103,7 +103,4 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
-	GlobalSection(Performance) = preSolution
-		HasPerformanceSessions = true
-	EndGlobalSection
 EndGlobal

--- a/MediaBrowser.UI/HiddenForm.cs
+++ b/MediaBrowser.UI/HiddenForm.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
+using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
 using System.Text;
@@ -14,6 +15,7 @@ namespace MediaBrowser.UI
     {
         private const int WM_APP = 0x8000;
         private const int WM_GRAPHNOTIFY = WM_APP + 1;
+        private const int WM_DVD_EVENT = 0x00008002;
         
         public HiddenForm()
         {
@@ -21,15 +23,24 @@ namespace MediaBrowser.UI
         }
 
         public Action OnWMGRAPHNOTIFY { get; set; }
+        public Action OnDVDEVENT { get; set; }
 
         protected override void WndProc(ref Message m)
         {
-            if (m.Msg == WM_GRAPHNOTIFY)
+            switch (m.Msg)
             {
-                if (OnWMGRAPHNOTIFY != null)
-                {
-                    OnWMGRAPHNOTIFY();
-                }
+                case WM_GRAPHNOTIFY:
+                    if (OnWMGRAPHNOTIFY != null)
+                    {
+                        OnWMGRAPHNOTIFY();
+                    }
+                    break;
+                case WM_DVD_EVENT:
+                    if (OnDVDEVENT != null)
+                    {
+                        OnDVDEVENT();
+                    }
+                    break;
             }
             
             base.WndProc(ref m);

--- a/MediaBrowser.UI/Implementations/AppHiddenWIndow.cs
+++ b/MediaBrowser.UI/Implementations/AppHiddenWIndow.cs
@@ -28,6 +28,24 @@ namespace MediaBrowser.UI.Implementations
             }
         }
 
+        public event KeyEventHandler KeyDown
+        {
+            add { App.Instance.HiddenWindow.KeyDown += value; }
+            remove
+            {
+                App.Instance.HiddenWindow.KeyDown -= value;
+            }
+        }
+
+        public event MouseEventHandler MouseClick
+        {
+            add { App.Instance.HiddenWindow.MouseClick += value; }
+            remove
+            {
+                App.Instance.HiddenWindow.MouseClick -= value;
+            }
+        }
+
         public Size ContentPixelSize
         {
             get { return new Size(App.Instance.HiddenWindow.Width, App.Instance.HiddenWindow.Height); }
@@ -45,6 +63,17 @@ namespace MediaBrowser.UI.Implementations
             }
         }
 
+        public Action OnDVDEVENT
+        {
+            get
+            {
+                return App.Instance.HiddenWindow.OnDVDEVENT;
+            }
+            set
+            {
+                App.Instance.HiddenWindow.OnDVDEVENT = value;
+            }
+        }
 
         //private Size GetElementPixelSize(Grid element)
         //{


### PR DESCRIPTION
Add preliminary support for DVD menus
Stop loading XySubFilter filter for DVDs because it's not necessary
Add framework for handling DVD messages
Use a single IBaseFilter object to encapsulate all sources
Init all DShow interfaces and objects to null
ROT publish the playback graph (TODO: make this optional)
