### PR TITLE
Expose LAV filter settings

### DIFF
--- a/MediaBrowser.Theater.DirectShow/DirectShowPlayer.cs
+++ b/MediaBrowser.Theater.DirectShow/DirectShowPlayer.cs
@@ -79,11 +79,56 @@ namespace MediaBrowser.Theater.DirectShow
         private VideoConfiguration _videoConfig;
         private AudioConfiguration _audioConfig;
 
-        //TODO: this should be in the video configuration class, but what's the best way to migrate the interfaces there?
-        public static string[] GetLAVVideoHwaCodecs()
+        #region LAVConfigurationValues
+
+        public static List<string> GetLAVVideoHwaCodecs()
         {
-            return Enum.GetNames(typeof(LAVVideoHWCodec));
+            return BuildListFromEnumType(typeof(LAVVideoHWCodec));
         }
+
+        public static List<string> GetLAVVideoCodecs()
+        {
+            return BuildListFromEnumType(typeof(LAVVideoCodec));
+        }
+
+        public static List<string> GetLAVVideoHWAResolutions()
+        {
+            return BuildListFromEnumType(typeof(LAVHWResFlag));
+        }
+
+        public static List<string> GetLAVAudioCodecs()
+        {
+            return BuildListFromEnumType(typeof(LAVAudioCodec));
+        }
+
+        public static List<string> GetLAVAudioMixingModes()
+        {
+            return BuildListFromEnumType(typeof(LAVAudioMixingMode));
+        }
+
+        public static List<string> GetLAVAudioMixingControl()
+        {
+            return BuildListFromEnumType(typeof(LAVAudioMixingFlag));
+        }
+
+        public static List<string> GetLAVAudioMixingLayout()
+        {
+            return BuildListFromEnumType(typeof(LAVAudioMixingLayout));
+        }
+
+        private static List<string> BuildListFromEnumType(Type enumType)
+        {
+            List<string> values = new List<string>();
+            foreach (string etype in Enum.GetNames(enumType))
+            {
+                if (etype != "NB")
+                    values.Add(etype);
+            }
+
+            return values;
+        }
+
+        #endregion
 
         public DirectShowPlayer(ILogger logger, IHiddenWindow hiddenWindow, InternalDirectShowPlayer playerWrapper, IntPtr applicationWindowHandle)
         {
@@ -381,8 +426,29 @@ namespace MediaBrowser.Theater.DirectShow
                                 DsError.ThrowExceptionForHR(hr);
                             }
 
-                            string[] hwaCodecs = DirectShowPlayer.GetLAVVideoHwaCodecs();
-                            foreach (string hwaCodec in hwaCodecs)
+                            foreach (string c in DirectShowPlayer.GetLAVVideoCodecs())
+                            {
+                                LAVVideoCodec codec = (LAVVideoCodec)Enum.Parse(typeof(LAVVideoCodec), c);
+
+                                bool isEnabled = vsett.GetFormatConfiguration(codec);
+                                if (_videoConfig.EnabledCodecs.Contains(c))
+                                {
+                                    if (!isEnabled)
+                                    {
+                                        _logger.Debug("Enable support for: {0}", c);
+                                        hr = vsett.SetFormatConfiguration(codec, true);
+                                        DsError.ThrowExceptionForHR(hr);
+                                    }
+                                }
+                                else if (isEnabled)
+                                {
+                                    _logger.Debug("Disable support for: {0}", c);
+                                    hr = vsett.SetFormatConfiguration(codec, false);
+                                    DsError.ThrowExceptionForHR(hr);
+                                }
+                            }
+
+                            foreach (string hwaCodec in DirectShowPlayer.GetLAVVideoHwaCodecs())
                             {
                                 LAVVideoHWCodec codec = (LAVVideoHWCodec)Enum.Parse(typeof(LAVVideoHWCodec), hwaCodec);
                                 bool hwaIsEnabled = vsett.GetHWAccelCodec(codec);
@@ -410,6 +476,14 @@ namespace MediaBrowser.Theater.DirectShow
                                 hr = vsett.SetDVDVideoSupport(true);
                                 DsError.ThrowExceptionForHR(hr);
                             }
+
+                            int hwaRes = vsett.GetHWAccelResolutionFlags();
+                            if (hwaRes != _videoConfig.HwaResolution)
+                            {
+                                _logger.Debug("Change HWA resolution support from {0} to {1}.", hwaRes, _videoConfig.HwaResolution);
+                                hr = vsett.SetHWAccelResolutionFlags(_videoConfig.HwaResolution);
+                                DsError.ThrowExceptionForHR(hr);
+                            }
                         }
                     }
                 }
@@ -434,6 +508,28 @@ namespace MediaBrowser.Theater.DirectShow
                             hr = asett.SetRuntimeConfig(true);
                             DsError.ThrowExceptionForHR(hr);
 
+                            foreach (string c in DirectShowPlayer.GetLAVAudioCodecs())
+                            {
+                                LAVAudioCodec codec = (LAVAudioCodec)Enum.Parse(typeof(LAVAudioCodec), c);
+
+                                bool isEnabled = asett.GetFormatConfiguration(codec);
+                                if (_audioConfig.EnabledCodecs.Contains(c))
+                                {
+                                    if (!isEnabled)
+                                    {
+                                        _logger.Debug("Enable support for: {0}", c);
+                                        hr = asett.SetFormatConfiguration(codec, true);
+                                        DsError.ThrowExceptionForHR(hr);
+                                    }
+                                }
+                                else if (isEnabled)
+                                {
+                                    _logger.Debug("Disable support for: {0}", c);
+                                    hr = asett.SetFormatConfiguration(codec, false);
+                                    DsError.ThrowExceptionForHR(hr);
+                                }
+                            }
+
                             //enable/disable bitstreaming
                             if((_audioConfig.AudioBitstreaming & BitstreamChoice.SPDIF) == BitstreamChoice.SPDIF)
                             {
@@ -443,6 +539,7 @@ namespace MediaBrowser.Theater.DirectShow
                                 hr = asett.SetBitstreamConfig(LAVBitstreamCodec.DTS, true);
                                 DsError.ThrowExceptionForHR(hr);
                             }
+
                             if((_audioConfig.AudioBitstreaming & BitstreamChoice.HDMI) == BitstreamChoice.HDMI)
                             {
 
@@ -453,6 +550,58 @@ namespace MediaBrowser.Theater.DirectShow
                                 DsError.ThrowExceptionForHR(hr);
 
                                 hr = asett.SetBitstreamConfig(LAVBitstreamCodec.DTSHD, true);
+                                DsError.ThrowExceptionForHR(hr);
+                            }
+
+                            if (_audioConfig.Delay > 0)
+                            {
+                                hr = asett.SetAudioDelay(true, _audioConfig.Delay);
+                                DsError.ThrowExceptionForHR(hr);
+                            }
+
+                            hr = asett.SetAutoAVSync(_audioConfig.EnableAutoSync);
+                            DsError.ThrowExceptionForHR(hr);
+
+                            hr = asett.SetExpand61(_audioConfig.Expand61);
+                            DsError.ThrowExceptionForHR(hr);
+
+                            hr = asett.SetExpandMono(_audioConfig.ExpandMono);
+                            DsError.ThrowExceptionForHR(hr);
+
+                            hr = asett.SetOutputStandardLayout(_audioConfig.ConvertToStandardLayout);
+                            DsError.ThrowExceptionForHR(hr);
+
+                            hr = asett.SetDRC(_audioConfig.EnableDRC, _audioConfig.DRCLevel);
+                            DsError.ThrowExceptionForHR(hr);
+                            
+                            bool mixingEnabled = asett.GetMixingEnabled();
+                            if (mixingEnabled != _audioConfig.EnablePCMMixing)
+                            {
+                                hr = asett.SetMixingEnabled(!mixingEnabled);
+                                DsError.ThrowExceptionForHR(hr);
+                            }
+
+                            if (_audioConfig.EnablePCMMixing)
+                            {
+                                LAVAudioMixingFlag amf = (LAVAudioMixingFlag)_audioConfig.MixingSetting;
+                                hr = asett.SetMixingFlags(amf);
+                                DsError.ThrowExceptionForHR(hr);
+
+                                LAVAudioMixingMode amm = (LAVAudioMixingMode)Enum.Parse(typeof(LAVAudioMixingMode), _audioConfig.MixingEncoding);
+                                hr = asett.SetMixingMode(amm);
+                                DsError.ThrowExceptionForHR(hr);
+
+                                LAVAudioMixingLayout aml = (LAVAudioMixingLayout)Enum.Parse(typeof(LAVAudioMixingLayout), _audioConfig.MixingLayout);
+                                hr = asett.SetMixingLayout(aml);
+                                DsError.ThrowExceptionForHR(hr);
+
+                                int lfe, center, surround;
+                                //convert to the # that LAV Audio expects
+                                lfe = (int)(_audioConfig.LfeMixingLevel * 10000.01);
+                                center = (int)(_audioConfig.CenterMixingLevel * 10000.01);
+                                surround = (int)(_audioConfig.SurroundMixingLevel * 10000.01);
+
+                                hr = asett.SetMixingLevels(center, surround, lfe);
                                 DsError.ThrowExceptionForHR(hr);
                             }
 

--- a/MediaBrowser.Theater.Interfaces/Configuration/InternalPlayerConfiguration.cs
+++ b/MediaBrowser.Theater.Interfaces/Configuration/InternalPlayerConfiguration.cs
@@ -34,7 +34,9 @@ namespace MediaBrowser.Theater.Interfaces.Configuration
         {
             //set defaults if necessary
             VideoConfig = new VideoConfiguration();
+            VideoConfig.SetDefaults();
             AudioConfig = new AudioConfiguration();
+            AudioConfig.SetDefaults();
         }
     }
 
@@ -73,79 +75,109 @@ namespace MediaBrowser.Theater.Interfaces.Configuration
         /// <summary>
         /// Gets or sets a value indicating overridden video HWA mode.
         /// </summary>
-        /// <value><c>> -1</c> if user has overridden; otherwise, <c>-1</c>.</value>
-        private int _hwaMode = -1;
-        public int HwaMode
-        {
-            get
-            {
-                if (_hwaMode > -1)
-                    return _hwaMode;
-                else
-                {
-                    if (GpuModel.IndexOf("Intel") > -1)
-                        return 2; //LAVHWAccel.QuickSync;
-                    else
-                        return 3; // LAVHWAccel.DXVA2CopyBack;
-                }
-            }
-            set
-            {
-                _hwaMode = value;
-            }
-        }
+        public int HwaMode { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating resolutions that will be HWA.
+        /// </summary>
+        /// equivalent to LAVHWResFlag which appears to be a bitwise comparison enum
+        public int HwaResolution { get; set; }
 
         /// <summary>
         /// Gets or sets a value enabling madVR smooth motion.
         /// </summary>
         /// <value><c>true</c> to enable; otherwise, <c>false</c>.</value>
-        private bool _useMadVrSmoothMotion = true;
-        public bool UseMadVrSmoothMotion
-        {
-            get
-            {
-                return _useMadVrSmoothMotion;
-            }
-            set
-            {
-                _useMadVrSmoothMotion = value;
-            }
-        }
-
+        public bool UseMadVrSmoothMotion {get; set;}
+        
         /// <summary>
         /// Gets or sets madVR smooth motion mode.
         /// </summary>
         /// <value><c>avoidJudder</c>, <c>almostAlways</c> or <c>always</c>.</value>
-        private string _madVrSmoothMotionMode = "avoidJudder";
-        public string MadVrSmoothMotionMode
-        {
-            get
-            {
-                return _madVrSmoothMotionMode;
-            }
-            set
-            {
-                _madVrSmoothMotionMode = value;
-            }
-        }
+        public string MadVrSmoothMotionMode { get; set; }
 
         /// <summary>
         /// Gets or sets video codecs that will be HWA. 
         /// </summary>
         public List<string> HwaEnabledCodecs { get; set; }
 
+        /// <summary>
+        /// Gets or sets video codecs that will be enabled. 
+        /// </summary>
+        public List<string> EnabledCodecs { get; set; }
+
         public VideoConfiguration()
+        {
+            HwaEnabledCodecs = new List<string>();
+            EnabledCodecs = new List<string>();
+
+            UseMadVrSmoothMotion = true;
+            MadVrSmoothMotionMode = "avoidJudder";
+
+            if (GpuModel.IndexOf("Intel") > -1)
+            {
+                HwaResolution = 7; // SD + HD + UHD
+                HwaMode = 2; //LAVHWAccel.QuickSync;
+            }
+            else
+            {
+                HwaResolution = 3; // SD + HD; 
+                HwaMode = 3; // LAVHWAccel.DXVA2CopyBack;
+            }
+        }
+
+        public void SetDefaults()
         {
             //reading through nevcariel's comments it appears that HWA DVD playback can have stability issues
             //and since most any PC should be able to manage it, we're not going to turn it on by default
             //also skip MPEG4 since most GPUs can't HWA and it's buggy
             //the full list of codecs can be had from DirectShowPlayer.GetLAVVideoHwaCodecs for UI config building
-            HwaEnabledCodecs = new List<string>();
             HwaEnabledCodecs.Add("H264");
             HwaEnabledCodecs.Add("VC1");
             HwaEnabledCodecs.Add("MPEG2");
             //HwaEnabledCodecs.Add("MPEG2DVD");
             //HwaEnabledCodecs.Add("MPEG4");
+
+            EnabledCodecs.Add("H264");
+            EnabledCodecs.Add("VC1");
+            EnabledCodecs.Add("MPEG1");
+            EnabledCodecs.Add("MPEG2");
+            EnabledCodecs.Add("MPEG4");
+            EnabledCodecs.Add("MSMPEG4");
+            EnabledCodecs.Add("VP8");
+            EnabledCodecs.Add("WMV3");
+            EnabledCodecs.Add("WMV12");
+            EnabledCodecs.Add("MJPEG");
+            EnabledCodecs.Add("Theora");
+            EnabledCodecs.Add("FLV1");
+            EnabledCodecs.Add("VP6");
+            EnabledCodecs.Add("SVQ");
+            EnabledCodecs.Add("H261");
+            EnabledCodecs.Add("H263");
+            EnabledCodecs.Add("Indeo");
+            EnabledCodecs.Add("TSCC");
+            EnabledCodecs.Add("Fraps");
+            EnabledCodecs.Add("HuffYUV");
+            EnabledCodecs.Add("QTRle");
+            EnabledCodecs.Add("DV");
+            EnabledCodecs.Add("Bink");
+            EnabledCodecs.Add("Smacker");
+            EnabledCodecs.Add("RV34");
+            EnabledCodecs.Add("Lagarith");
+            EnabledCodecs.Add("Camstudio");
+            EnabledCodecs.Add("ZLIB");
+            EnabledCodecs.Add("QTRpza");
+            EnabledCodecs.Add("PNG");
+            EnabledCodecs.Add("ProRes");
+            EnabledCodecs.Add("UtVideo");
+            EnabledCodecs.Add("Dirac");
+            EnabledCodecs.Add("DNxHD");
+            EnabledCodecs.Add("MSVideo1");
+            EnabledCodecs.Add("EightBPS");
+            EnabledCodecs.Add("LOCO");
+            EnabledCodecs.Add("ZMBV");
+            EnabledCodecs.Add("VCR1");
+            EnabledCodecs.Add("Snow");
+            EnabledCodecs.Add("FFV1");
         }
     }
 
@@ -164,5 +196,72 @@ namespace MediaBrowser.Theater.Interfaces.Configuration
         /// </summary>
         /// <value><c>true</c> if [enable audio bitstreaming]; otherwise, <c>false</c>.</value>
         public BitstreamChoice AudioBitstreaming { get; set; }
+
+        public int Delay { get; set; }
+
+        public bool EnableAutoSync { get; set; }
+        public bool ConvertToStandardLayout { get; set; }
+        public bool ExpandMono { get; set; }
+        public bool Expand61 { get; set; }
+        public bool EnableDRC { get; set; }
+        public int DRCLevel { get; set; }
+        public bool EnablePCMMixing { get; set; }
+        public string MixingEncoding { get; set; }
+        public string MixingLayout{ get; set; }
+        public int MixingSetting { get; set; }
+        public double LfeMixingLevel { get; set; }
+        public double CenterMixingLevel { get; set; }
+        public double SurroundMixingLevel { get; set; }
+
+        /// <summary>
+        /// Gets or sets audio codecs that will be enabled. 
+        /// </summary>
+        public List<string> EnabledCodecs { get; set; }
+
+        public AudioConfiguration()
+        {
+            EnabledCodecs = new List<string>(); 
+            
+            Delay = 0;
+            MixingEncoding = "None";
+            MixingLayout = "Stereo";
+            MixingSetting = 4; //"ClipProtection"
+            EnablePCMMixing = false;
+            EnableAutoSync = true;
+            ConvertToStandardLayout = true;
+            Expand61 = false;
+            ExpandMono = false;
+            EnableDRC = false;
+            DRCLevel = 100;
+            LfeMixingLevel = 0;
+            CenterMixingLevel = 0.7071;
+            SurroundMixingLevel = 0.7071;
+        }
+
+        public void SetDefaults()
+        {
+            EnabledCodecs.Add("AAC");
+            EnabledCodecs.Add("AC3");
+            EnabledCodecs.Add("EAC3");
+            EnabledCodecs.Add("DTS");
+            EnabledCodecs.Add("MP2");
+            EnabledCodecs.Add("MP3");
+            EnabledCodecs.Add("TRUEHD");
+            EnabledCodecs.Add("FLAC");
+            EnabledCodecs.Add("VORBIS");
+            EnabledCodecs.Add("LPCM");
+            EnabledCodecs.Add("PCM");
+            EnabledCodecs.Add("WAVPACK");
+            EnabledCodecs.Add("TTA");
+            EnabledCodecs.Add("Cook");
+            EnabledCodecs.Add("RealAudio");
+            EnabledCodecs.Add("ALAC");
+            EnabledCodecs.Add("Opus");
+            EnabledCodecs.Add("AMR");
+            EnabledCodecs.Add("Nellymoser");
+            EnabledCodecs.Add("MSPCM");
+            EnabledCodecs.Add("Truespeech");
+            EnabledCodecs.Add("TAK");
+        }
     }
 }


### PR DESCRIPTION
- Change how A/V config classes are initialized to keep the List<string>
  properties from getting duplicated entries due to serialization
- Add audio mixing config
- Add A/V codec control
- Add video HWA resolution control
- Add audio delay setting
- Add DRC setting
- Add channel expansion settings
- Add channel layout setting
- Add auto sync setting
