### PR TITLE
Respect the Auto/Rate/Seeking

### DIFF
--- a/MediaBrowser.Theater.DirectShow/DirectShowPlayer.cs
+++ b/MediaBrowser.Theater.DirectShow/DirectShowPlayer.cs
@@ -67,6 +67,9 @@ namespace MediaBrowser.Theater.DirectShow
         //private DirectShowLib.IBaseFilter _dvdNav = null;
         private IDvdControl2 _mDvdControl = null;
         //private IDvdInfo2 _mDvdInfo = null;
+        private IDvdCmd _mDvdCmdOption = null;
+        private bool _pendingDvdCmd;
+        private double _currentPlaybackRate = 1.0;
 
         private MadVR _madvr = null;
 
@@ -226,6 +229,7 @@ namespace MediaBrowser.Theater.DirectShow
             DsError.ThrowExceptionForHR(hr);
 
             PlayState = PlayState.Playing;
+            _currentPlaybackRate = 1.0;
 
             _streams = GetStreams();
         }
@@ -484,7 +488,7 @@ namespace MediaBrowser.Theater.DirectShow
                             if (hwaRes != _videoConfig.HwaResolution)
                             {
                                 _logger.Debug("Change HWA resolution support from {0} to {1}.", hwaRes, _videoConfig.HwaResolution);
-                                hr = vsett.SetHWAccelResolutionFlags(_videoConfig.HwaResolution);
+                                hr = vsett.SetHWAccelResolutionFlags(VideoConfigurationUtils.GetHwaResolutions(_videoConfig));
                                 DsError.ThrowExceptionForHR(hr);
                             }
 
@@ -1249,6 +1253,66 @@ namespace MediaBrowser.Theater.DirectShow
             OnStopped(reason, pos, newTrackIndex);
         }
 
+        private void ModifyRate(double dRateAdjust)
+        {
+            int hr = 0;
+            double dRate;
+
+            if (_mDvdControl != null)
+            {
+                _currentPlaybackRate += dRateAdjust;
+
+                if (_currentPlaybackRate == 0) _currentPlaybackRate += dRateAdjust;
+
+                if (_currentPlaybackRate < 0)
+                    hr = _mDvdControl.PlayBackwards(Math.Abs(_currentPlaybackRate), DvdCmdFlags.SendEvents, out _mDvdCmdOption);
+                else
+                    hr = _mDvdControl.PlayForwards(_currentPlaybackRate, DvdCmdFlags.SendEvents, out _mDvdCmdOption);
+                DsError.ThrowExceptionForHR(hr);
+
+                if (_mDvdCmdOption != null)
+                {
+                    _pendingDvdCmd = true;
+                }
+            }
+            else if ((_mediaSeeking != null) && (dRateAdjust != 0.0))
+            {
+                hr = _mediaSeeking.GetRate(out dRate);
+                if (hr == 0)
+                {
+                    // Add current rate to adjustment value
+                    double dNewRate = dRate + dRateAdjust;
+                    hr = this._mediaSeeking.SetRate(dNewRate);
+                    DsError.ThrowExceptionForHR(hr);
+
+                    // Save global rate
+                    _currentPlaybackRate = dNewRate;
+                }
+            }
+        }
+
+        public void SetRate(double rate)
+        {
+            int hr = 0;
+            _currentPlaybackRate = rate;
+
+            if (_mDvdControl != null)
+            {
+                hr = _mDvdControl.PlayForwards(rate, DvdCmdFlags.SendEvents, out _mDvdCmdOption);
+                DsError.ThrowExceptionForHR(hr);
+
+                if (_mDvdCmdOption != null)
+                {
+                    _pendingDvdCmd = true;
+                }
+            }
+            else if (_mediaSeeking != null)
+            {
+                hr = _mediaSeeking.SetRate(rate);
+                DsError.ThrowExceptionForHR(hr);
+            }
+        }
+
         public void Seek(long ticks)
         {
             if (_mediaSeeking != null)
@@ -1257,8 +1321,23 @@ namespace MediaBrowser.Theater.DirectShow
 
                 var hr = _mediaSeeking.GetDuration(out duration);
 
+                if (ticks < duration)
+                    ticks = 0;
+
                 // Seek to the position
                 hr = _mediaSeeking.SetPositions(new DsLong(ticks), AMSeekingSeekingFlags.AbsolutePositioning, new DsLong(duration), AMSeekingSeekingFlags.AbsolutePositioning);
+            }
+        }
+
+        public void SeekRelative(long ticks)
+        {
+            if (_mediaSeeking != null)
+            {
+                long position;
+
+                var hr = _mediaSeeking.GetCurrentPosition(out position);
+                position += ticks;
+                Seek(position);
             }
         }
 
@@ -1316,7 +1395,7 @@ namespace MediaBrowser.Theater.DirectShow
                         case EventCode.DvdCmdStart:
                             break;
                         case EventCode.DvdCmdEnd:
-                            //OnCmdComplete(evParam1, evParam2);
+                            OnDvdCmdComplete(evParam1, evParam2);
                             break;
                         case EventCode.DvdStillOn:
                             if (evParam1 == IntPtr.Zero)
@@ -1351,6 +1430,40 @@ namespace MediaBrowser.Theater.DirectShow
             {
 
             }
+        }
+
+        private void OnDvdCmdComplete(IntPtr evParam1, IntPtr evParam2)
+        {
+            IDvdInfo2 dvdInfo = _sourceFilter as IDvdInfo2;
+
+            if ((_pendingDvdCmd == false) || (dvdInfo == null))
+            {
+                return;
+            }
+
+            IDvdCmd cmd = null;
+            int hr = dvdInfo.GetCmdFromEvent(evParam1, out cmd);
+            DsError.ThrowExceptionForHR(hr);
+
+            if (cmd == null)
+            {
+                // DVD OnCmdComplete GetCmdFromEvent failed
+                return;
+            }
+
+            if (cmd != _mDvdCmdOption)
+            {
+                // DVD OnCmdComplete UNKNOWN CMD
+                Marshal.ReleaseComObject(cmd);
+                cmd = null;
+                return;
+            }
+
+            Marshal.ReleaseComObject(cmd);
+            cmd = null;
+            Marshal.ReleaseComObject(_mDvdCmdOption);
+            _mDvdCmdOption = null;
+            _pendingDvdCmd = false;
         }
 
         private void HandleGraphEvent()

--- a/MediaBrowser.Theater.DirectShow/Helpers.cs
+++ b/MediaBrowser.Theater.DirectShow/Helpers.cs
@@ -46,5 +46,16 @@ namespace MediaBrowser.Theater.DirectShow
             else
                 return 3; // LAVHWAccel.DXVA2CopyBack;
         }
+
+        public static int GetHwaResolutions(VideoConfiguration config)
+        {
+            if (config.HwaResolution > -1)
+                return config.HwaResolution;
+
+            if (GpuModel.IndexOf("Intel") > -1)
+                return 7; // SD + HD + UHD
+            else
+                return 3; // SD + HD;
+        }
     }
 }

--- a/MediaBrowser.Theater.Interfaces/Configuration/InternalPlayerConfiguration.cs
+++ b/MediaBrowser.Theater.Interfaces/Configuration/InternalPlayerConfiguration.cs
@@ -119,19 +119,19 @@ namespace MediaBrowser.Theater.Interfaces.Configuration
 
         public void SetDefaults()
         {
-            if (HwaMode < 0 || HwaResolution < 0)
-            {
-                if (GpuModel.IndexOf("Intel") > -1)
-                {
-                    HwaResolution = 7; // SD + HD + UHD
-                    HwaMode = 2; //LAVHWAccel.QuickSync;
-                }
-                else
-                {
-                    HwaResolution = 3; // SD + HD; 
-                    HwaMode = 3; // LAVHWAccel.DXVA2CopyBack;
-                }
-            }
+            //if (HwaMode < 0 || HwaResolution < 0)
+            //{
+            //    if (GpuModel.IndexOf("Intel") > -1)
+            //    {
+            //        HwaResolution = 7; // SD + HD + UHD
+            //        HwaMode = 2; //LAVHWAccel.QuickSync;
+            //    }
+            //    else
+            //    {
+            //        HwaResolution = 3; // SD + HD; 
+            //        HwaMode = 3; // LAVHWAccel.DXVA2CopyBack;
+            //    }
+            //}
             //reading through nevcariel's comments it appears that HWA DVD playback can have stability issues
             //and since most any PC should be able to manage it, we're not going to turn it on by default
             //also skip MPEG4 since most GPUs can't HWA and it's buggy


### PR DESCRIPTION
- Treat HwaMode(-1) as Auto instead of Unset
- Treat HwaResolution(-1) as Auto instead of Unset
- Add methods to modify rate (untested)
- Add method to allow for relative seeking (untested)
- Add check to ensure that we don't try to seek to a negative absolution
  position
