### PR TITLE
Add support for custom MP WASAPI Audio Renderer

### DIFF
--- a/MediaBrowser.Theater.DirectShow/AdditionalFilterInterfaces.cs
+++ b/MediaBrowser.Theater.DirectShow/AdditionalFilterInterfaces.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using MediaFoundation;
+
+namespace MediaBrowser.Theater.DirectShow
+{
+
+    #region Custom EVR Presenter
+
+    [ComImport,
+    Guid("D54059EF-CA38-46A5-9123-0249770482EE"),
+    InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IEVRCPSettings
+    {
+        [PreserveSig]
+        int SetNominalRange(MFNominalRange range);
+
+        [PreserveSig]
+        MFNominalRange GetNominalRange();
+    }
+
+    #endregion
+
+    #region WASAPI Audio Renderer
+
+    public enum AUDCLNT_SHAREMODE
+    {
+        SHARED,
+        EXCLUSIVE
+    }
+
+    public enum SpeakerConfig
+    {
+        Mono = 4,
+        Stereo = 3,
+        Quad = 51,
+        Surround = 263,
+        FiveDotOne = 63,
+        FiveDotOneSurround = 1551,
+        SevenDotOneSurround = 1599
+    }
+
+    [ComImport, System.Security.SuppressUnmanagedCodeSecurity,
+    Guid("CA0CDCD8-D26B-4F8F-B23C-D8D949B14297"),
+    InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IMPAudioSettings
+    {
+        [PreserveSig]
+        int GetAC3EncodingMode(out int setting);
+        [PreserveSig]
+        int SetAC3EncodingMode(int setting);
+
+        [PreserveSig]
+        int GetLogSampleTimes(out bool setting);
+        [PreserveSig]
+        int SetLogSampleTimes(bool setting);
+
+        [PreserveSig]
+        int GetEnableSyncAdjustment(out bool setting);
+        [PreserveSig]
+        int SetEnableSyncAdjustment(bool setting);
+
+        [PreserveSig]
+        int GetWASAPIMode(out AUDCLNT_SHAREMODE setting);
+        [PreserveSig]
+        int SetWASAPIMode(AUDCLNT_SHAREMODE setting);
+
+        [PreserveSig]
+        int GetUseWASAPIEventMode(out bool setting);
+        [PreserveSig]
+        int SetUseWASAPIEventMode(bool setting);
+
+        [PreserveSig]
+        int GetUseTimeStretching(out bool setting);
+        [PreserveSig]
+        int SetUseTimeStretching(bool setting);
+
+        [PreserveSig]
+        int GetExpandMonoToStereo(out bool setting);
+        [PreserveSig]
+        int SetExpandMonoToStereo(bool setting);
+
+        [PreserveSig]
+        int GetAC3Bitrate(out int setting);
+        [PreserveSig]
+        int SetAC3Bitrate(int setting);
+
+        [PreserveSig]
+        int GetSpeakerConfig(out SpeakerConfig setting);
+        [PreserveSig]
+        int SetSpeakerConfig(SpeakerConfig setting);
+
+        [PreserveSig]
+        int GetForceChannelMixing(out bool setting);
+        [PreserveSig]
+        int SetForceChannelMixing(bool setting);
+
+        [PreserveSig]
+        int GetAudioDelay(out int setting);
+        [PreserveSig]
+        int SetAudioDelay(int setting);
+
+        [PreserveSig]
+        int GetOutputBuffer(out int setting);
+        [PreserveSig]
+        int SetOutputBuffer(int setting);
+
+        [PreserveSig]
+        int GetSampleRate(out int setting);
+        [PreserveSig]
+        int SetSampleRate(int setting);
+
+        [PreserveSig]
+        int GetBitDepth(out int setting);
+        [PreserveSig]
+        int SetBitDepth(int setting);
+
+        [PreserveSig]
+        int GetResamplingQuality(out int setting);
+        [PreserveSig]
+        int SetResamplingQuality(int setting);
+
+        [PreserveSig]
+        int GetAvailableAudioDevices(
+            /*[Out, MarshalAs(UnmanagedType.LPArray)]
+            out DeviceDefinition[]*/
+            out IntPtr devices,
+            out int count); //doesn't work
+        [PreserveSig]
+        int SetAudioDevice(int setting);
+        [PreserveSig]
+        int SetAudioDeviceById([In, MarshalAs(UnmanagedType.LPWStr)] string setting);
+    }
+
+    #endregion
+}

--- a/MediaBrowser.Theater.DirectShow/Configuration/ConfigurationPage.xaml
+++ b/MediaBrowser.Theater.DirectShow/Configuration/ConfigurationPage.xaml
@@ -20,12 +20,15 @@
         
         <StackPanel Orientation="Horizontal" Margin="0 10 0 0">
             <TextBlock Style="{StaticResource TextBlockStyle}" Margin="0 0 0 0">Audio Bitstreaming Mode:</TextBlock>
-            <controls:SelectList x:Name="SelectudioBitstreamingMode" Margin="85 0 0 0"></controls:SelectList>
+            <controls:SelectList x:Name="SelectAudioBitstreamingMode" Margin="85 0 0 0"></controls:SelectList>
         </StackPanel>
-
-        <CheckBox x:Name="ChkEnableReclock" Margin="0 30 0 0" VerticalAlignment="Center">
+        <StackPanel Orientation="Horizontal" Margin="0 10 0 0">
+            <TextBlock Style="{StaticResource TextBlockStyle}" Margin="0 0 0 0"><Run Text="Audio Renderer:"/></TextBlock>
+            <controls:SelectList x:Name="SelectAudioRenderer" Margin="212 0 0 0"/>
+        </StackPanel>
+        <!--<CheckBox x:Name="ChkEnableReclock" Margin="0 30 0 0" VerticalAlignment="Center">
             <TextBlock Style="{StaticResource TextBlockStyle}">Enable Reclock *</TextBlock>
-        </CheckBox>
+        </CheckBox>-->
         <StackPanel Orientation="Horizontal" Margin="0 10 0 0">
             <CheckBox x:Name="ChkEnableMadvr" Margin="0 30 0 0" VerticalAlignment="Center">
                 <TextBlock Style="{StaticResource TextBlockStyle}" >Enable madVR *</TextBlock>

--- a/MediaBrowser.Theater.DirectShow/Configuration/ConfigurationPage.xaml.cs
+++ b/MediaBrowser.Theater.DirectShow/Configuration/ConfigurationPage.xaml.cs
@@ -47,13 +47,19 @@ namespace MediaBrowser.Theater.DirectShow.Configuration
                  new SelectListItem{ Text = "DXVA2CopyBack", Value="3"}
             };
 
-            SelectudioBitstreamingMode.Options = new List<SelectListItem>();
+            SelectAudioBitstreamingMode.Options = new List<SelectListItem>();
 
             foreach (string bsOption in Enum.GetNames(typeof(BitstreamChoice)))
             {
-                SelectudioBitstreamingMode.Options.Add(new SelectListItem { Text = bsOption, Value = bsOption });
+                SelectAudioBitstreamingMode.Options.Add(new SelectListItem { Text = bsOption, Value = bsOption });
             }
 
+            SelectAudioRenderer.Options = new List<SelectListItem>();
+
+            foreach (string bsOption in Enum.GetNames(typeof(AudioRendererChoice)))
+            {
+                SelectAudioRenderer.Options.Add(new SelectListItem { Text = bsOption, Value = bsOption });
+            }
         }
 
         void BtnConfigureSubtitles_Click(object sender, RoutedEventArgs e)
@@ -85,22 +91,24 @@ namespace MediaBrowser.Theater.DirectShow.Configuration
         {
             var config = _config.Configuration.InternalPlayerConfiguration;
 
-            ChkEnableReclock.IsChecked = config.EnableReclock;
-            ChkEnableMadvr.IsChecked = config.EnableMadvr;
-            ChkEnableXySubFilter.IsChecked = config.EnableXySubFilter;
-            SelectudioBitstreamingMode.SelectedValue = config.AudioConfig.AudioBitstreaming.ToString();
+            //ChkEnableReclock.IsChecked = config.EnableReclock;
+            ChkEnableMadvr.IsChecked = config.VideoConfig.EnableMadvr;
+            ChkEnableXySubFilter.IsChecked = config.SubtitleConfig.EnableXySubFilter;
+            SelectAudioBitstreamingMode.SelectedValue = config.AudioConfig.AudioBitstreaming.ToString();
             SelectHwaMode.SelectedValue = config.VideoConfig.HwaMode.ToString();
+            SelectAudioRenderer.SelectedValue = config.AudioConfig.Renderer.ToString();            
         }
 
         void GeneralSettingsPage_Unloaded(object sender, RoutedEventArgs e)
         {
             var config = _config.Configuration.InternalPlayerConfiguration;
 
-            config.EnableReclock = ChkEnableReclock.IsChecked ?? false;
-            config.EnableMadvr = ChkEnableMadvr.IsChecked ?? false;
-            config.EnableXySubFilter = ChkEnableXySubFilter.IsChecked ?? false;
+            //config.EnableReclock = ChkEnableReclock.IsChecked ?? false;
+            config.VideoConfig.EnableMadvr = ChkEnableMadvr.IsChecked ?? false;
+            config.SubtitleConfig.EnableXySubFilter = ChkEnableXySubFilter.IsChecked ?? false;
 
-            config.AudioConfig.AudioBitstreaming = (BitstreamChoice)Enum.Parse(typeof(BitstreamChoice), SelectudioBitstreamingMode.SelectedValue);
+            config.AudioConfig.AudioBitstreaming = (BitstreamChoice)Enum.Parse(typeof(BitstreamChoice), SelectAudioBitstreamingMode.SelectedValue);
+            config.AudioConfig.Renderer = (AudioRendererChoice)Enum.Parse(typeof(AudioRendererChoice), SelectAudioRenderer.SelectedValue);
 
             config.VideoConfig.HwaMode = int.Parse(SelectHwaMode.SelectedValue);
 

--- a/MediaBrowser.Theater.DirectShow/Configuration/LavAudioSettingsPage.xaml
+++ b/MediaBrowser.Theater.DirectShow/Configuration/LavAudioSettingsPage.xaml
@@ -6,7 +6,7 @@
       mc:Ignorable="d" 
       xmlns:controls="clr-namespace:MediaBrowser.Theater.Presentation.Controls;assembly=MediaBrowser.Theater.Presentation"
       d:DesignHeight="1000" d:DesignWidth="1450"
-	Title="LavAudioSettings">
+	Title="Audio Settings">
 
     <Grid Width="1450">
         <Grid.ColumnDefinitions>
@@ -64,6 +64,10 @@
         <StackPanel Orientation="Horizontal" Margin="0 50 0 0" Grid.Column="0" Grid.Row="7" >
             <TextBlock Style="{StaticResource TextBlockStyle}" Margin="0 0 0 0">Mixing Setting:</TextBlock>
             <controls:SelectList x:Name="SelectMixingSetting" Margin="40 0 0 0"></controls:SelectList>
+        </StackPanel>
+        <StackPanel Orientation="Horizontal" Margin="0 50 0 0" Grid.Column="1" Grid.Row="7" >
+            <TextBlock Style="{StaticResource TextBlockStyle}" Margin="0 0 0 0">Audio Device (WASAPI):</TextBlock>
+            <controls:SelectList x:Name="SelectAudioDevice" Margin="40 0 0 0"></controls:SelectList>
         </StackPanel>
         <CheckBox x:Name="ChkShowTrayIcon" Margin="0 30 0 0" VerticalAlignment="Center" Grid.Column="0" Grid.Row="8" >
             <TextBlock Style="{StaticResource TextBlockStyle}">ShowTrayIcon</TextBlock>

--- a/MediaBrowser.Theater.DirectShow/Configuration/LavAudioSettingsPage.xaml.cs
+++ b/MediaBrowser.Theater.DirectShow/Configuration/LavAudioSettingsPage.xaml.cs
@@ -69,6 +69,13 @@ namespace MediaBrowser.Theater.DirectShow.Configuration
                  new SelectListItem{ Text = "Normalize Matrix", Value="2"},
                  new SelectListItem{ Text = "Clip Protection", Value="4"}
             };
+
+            SelectAudioDevice.Options = new List<SelectListItem>();
+            Dictionary<string, string> audioDevices = AudioConfigurationUtils.GetAudioDevices();
+            foreach (string bsOption in audioDevices.Keys)
+            {
+                SelectAudioDevice.Options.Add(new SelectListItem { Text = bsOption, Value = audioDevices[bsOption] });
+            }
         }
 
         void GeneralSettingsPage_Loaded(object sender, RoutedEventArgs e)
@@ -88,6 +95,7 @@ namespace MediaBrowser.Theater.DirectShow.Configuration
             SelectMixingEncoding.SelectedValue = config.AudioConfig.MixingEncoding;
             SelectMixingLayout.SelectedValue = config.AudioConfig.MixingLayout;
             SelectMixingSetting.SelectedValue = config.AudioConfig.MixingSetting.ToString();
+            SelectAudioDevice.SelectedValue = config.AudioConfig.AudioDevice;
 
             SldDRCLevel.Value = config.AudioConfig.DRCLevel;
 
@@ -128,6 +136,7 @@ namespace MediaBrowser.Theater.DirectShow.Configuration
             config.AudioConfig.MixingEncoding = SelectMixingEncoding.SelectedValue;
             config.AudioConfig.MixingLayout = SelectMixingLayout.SelectedValue;
             config.AudioConfig.MixingSetting = int.Parse(SelectMixingSetting.SelectedValue);
+            config.AudioConfig.AudioDevice = SelectAudioDevice.SelectedValue;
 
             config.AudioConfig.DRCLevel = (int)SldDRCLevel.Value;
             config.AudioConfig.EnabledCodecs.Clear();

--- a/MediaBrowser.Theater.DirectShow/FileDownloader.cs
+++ b/MediaBrowser.Theater.DirectShow/FileDownloader.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MediaBrowser.Theater.DirectShow
+{
+    public class FileDownloader : IDisposable
+    {
+        ManualResetEvent _mreBlock = new ManualResetEvent(false);
+        bool _disposed = false;
+        byte[] _result = new byte[]{};
+        WebClient _wc = new WebClient();
+
+        public FileDownloader()
+        {
+            _wc.DownloadDataCompleted += FileDownloader_DownloadDataCompleted;
+            _wc.DownloadProgressChanged += _wc_DownloadProgressChanged;
+        }
+
+        void _wc_DownloadProgressChanged(object sender, DownloadProgressChangedEventArgs e)
+        {
+            //throw new NotImplementedException();
+        }
+
+        void FileDownloader_DownloadDataCompleted(object sender, DownloadDataCompletedEventArgs e)
+        {
+            _result = e.Result;
+            _mreBlock.Set();
+        }
+
+        public byte[] DownloadBlock(Uri address)
+        {
+            _mreBlock.Reset();
+            _wc.DownloadDataAsync(address);
+            _mreBlock.WaitOne();
+            return _result;
+        }
+
+        //protected override void OnDownloadDataCompleted(DownloadDataCompletedEventArgs e)
+        //{
+        //    _result = e.Result;
+        //    _mreBlock.Set();
+        //    base.OnDownloadDataCompleted(e);
+        //}
+
+        protected void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    if (_mreBlock != null)
+                        _mreBlock.Dispose();
+
+                    if (_wc != null)
+                        _wc.Dispose();
+                }
+                _disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/MediaBrowser.Theater.DirectShow/Helpers.cs
+++ b/MediaBrowser.Theater.DirectShow/Helpers.cs
@@ -1,6 +1,8 @@
 ﻿using MediaBrowser.Theater.Interfaces.Configuration;
 using System;
 using System.Management;
+using System.Collections.Generic;
+using CoreAudioApi;
 
 namespace MediaBrowser.Theater.DirectShow
 {
@@ -60,6 +62,25 @@ namespace MediaBrowser.Theater.DirectShow
                 return 7; // SD + HD + UHD
             else
                 return 3; // SD + HD;
+        }
+    }
+
+    public static class AudioConfigurationUtils
+    {
+        public static Dictionary<string, string> GetAudioDevices()
+        {
+            Dictionary<string, string> audioDevices = new Dictionary<string, string>();
+
+            audioDevices["Default Device"] = string.Empty;
+
+            MMDeviceEnumerator DevEnum = new MMDeviceEnumerator();
+            MMDeviceCollection dc = DevEnum.EnumerateAudioEndPoints(EDataFlow.eRender, EDeviceState.DEVICE_STATE_ACTIVE);
+            for (int i = 0; i < dc.Count; i++)
+            {
+                audioDevices[dc[i].FriendlyName] = dc[i].ID;
+            }
+
+            return audioDevices;
         }
     }
 }

--- a/MediaBrowser.Theater.DirectShow/Imports.cs
+++ b/MediaBrowser.Theater.DirectShow/Imports.cs
@@ -33,6 +33,11 @@ namespace MediaBrowser.Theater.DirectShow
     {
     }
 
+    [ComImport, Guid("EC9ED6FC-7B03-4CB6-8C01-4EABE109F26B")]
+    internal class MPAudioFilter
+    {
+    }
+
     [ComImport, Guid("93A22E7A-5091-45EF-BA61-6DA26156A5D0")]
     internal class XYVSFilter
     {

--- a/MediaBrowser.Theater.DirectShow/InternalDirectShowPlayer.cs
+++ b/MediaBrowser.Theater.DirectShow/InternalDirectShowPlayer.cs
@@ -227,9 +227,9 @@ namespace MediaBrowser.Theater.DirectShow
             try
             {
                 var enableMadVr = EnableMadvr(options);
-                var enableReclock = EnableReclock(options);
+                //var enableReclock = EnableReclock(options);
 
-                InvokeOnPlayerThread(() => _mediaPlayer.Play(playableItem, enableReclock, enableMadVr, false));
+                InvokeOnPlayerThread(() => _mediaPlayer.Play(playableItem, enableMadVr, false));
             }
             catch
             {
@@ -302,7 +302,7 @@ namespace MediaBrowser.Theater.DirectShow
                 return false;
             }
 
-            if (!_config.Configuration.InternalPlayerConfiguration.EnableMadvr)
+            if (!_config.Configuration.InternalPlayerConfiguration.VideoConfig.EnableMadvr)
             {
                 return false;
             }
@@ -320,27 +320,27 @@ namespace MediaBrowser.Theater.DirectShow
         /// </summary>
         /// <param name="options">The options.</param>
         /// <returns><c>true</c> if XXXX, <c>false</c> otherwise</returns>
-        private bool EnableReclock(PlayOptions options)
-        {
-            var video = options.Items.First();
+        //private bool EnableReclock(PlayOptions options)
+        //{
+        //    var video = options.Items.First();
 
-            if (!video.IsVideo)
-            {
-                return false;
-            }
+        //    if (!video.IsVideo)
+        //    {
+        //        return false;
+        //    }
 
-            if (!_config.Configuration.InternalPlayerConfiguration.EnableReclock)
-            {
-                return false;
-            }
+        //    if (!_config.Configuration.InternalPlayerConfiguration.EnableReclock)
+        //    {
+        //        return false;
+        //    }
 
-            if (!options.GoFullScreen)
-            {
-                return false;
-            }
+        //    if (!options.GoFullScreen)
+        //    {
+        //        return false;
+        //    }
             
-            return true;
-        }
+        //    return true;
+        //}
 
         private void DisposePlayer()
         {

--- a/MediaBrowser.Theater.DirectShow/MediaBrowser.Theater.DirectShow.csproj
+++ b/MediaBrowser.Theater.DirectShow/MediaBrowser.Theater.DirectShow.csproj
@@ -35,6 +35,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Accessibility" />
+    <Reference Include="CoreAudioApi">
+      <HintPath>..\ThirdParty\CoreAudioApi\CoreAudioApi.dll</HintPath>
+    </Reference>
     <Reference Include="DirectShowLib-2005, Version=2.0.0.0, Culture=neutral, PublicKeyToken=67e7b740cdfc2d3f, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>Assemblies\DirectShowLib-2005.dll</HintPath>
@@ -82,6 +85,7 @@
     <Reference Include="WindowsFormsIntegration" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AdditionalFilterInterfaces.cs" />
     <Compile Include="Configuration\ConfigurationPage.xaml.cs">
       <DependentUpon>ConfigurationPage.xaml</DependentUpon>
     </Compile>

--- a/MediaBrowser.Theater.Interfaces/Configuration/InternalPlayerConfiguration.cs
+++ b/MediaBrowser.Theater.Interfaces/Configuration/InternalPlayerConfiguration.cs
@@ -14,19 +14,7 @@ namespace MediaBrowser.Theater.Interfaces.Configuration
         /// Gets or sets a value indicating whether [enable reclock].
         /// </summary>
         /// <value><c>true</c> if [enable reclock]; otherwise, <c>false</c>.</value>
-        public bool EnableReclock { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether [enable madvr].
-        /// </summary>
-        /// <value><c>true</c> if [enable madvr]; otherwise, <c>false</c>.</value>
-        public bool EnableMadvr { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether [enable xy sub filter].
-        /// </summary>
-        /// <value><c>true</c> if [enable xy sub filter]; otherwise, <c>false</c>.</value>
-        public bool EnableXySubFilter { get; set; }
+        //public bool EnableReclock { get; set; }
 
         public bool UsePrivateObjects { get; set; }
 
@@ -48,7 +36,9 @@ namespace MediaBrowser.Theater.Interfaces.Configuration
             UsePrivateObjects = true;
         }
     }
-    
+
+    #region VideoConfig
+
     //add configuration values here as necessary
     public class VideoConfiguration
     {
@@ -118,6 +108,12 @@ namespace MediaBrowser.Theater.Interfaces.Configuration
 
         public bool UseCustomPresenter { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether [enable madvr].
+        /// </summary>
+        /// <value><c>true</c> if [enable madvr]; otherwise, <c>false</c>.</value>
+        public bool EnableMadvr { get; set; }
+        
         public VideoConfiguration()
         {
             HwaEnabledCodecs = new List<string>();
@@ -207,11 +203,22 @@ namespace MediaBrowser.Theater.Interfaces.Configuration
         }
     }
 
+    #endregion
+
+    #region AudioConfig
+
     public enum BitstreamChoice
     {
         None = 0,
         SPDIF = 1,
         HDMI = 3
+    }
+
+    public enum AudioRendererChoice
+    {
+        Default,
+        Reclock,
+        WASAPI
     }
 
     //add configuration values here as necessary
@@ -239,6 +246,8 @@ namespace MediaBrowser.Theater.Interfaces.Configuration
         public double CenterMixingLevel { get; set; }
         public double SurroundMixingLevel { get; set; }
         public bool ShowTrayIcon { get; set; }
+        public AudioRendererChoice Renderer { get; set; }
+        public string AudioDevice { get; set; }
 
         /// <summary>
         /// Gets or sets audio codecs that will be enabled. 
@@ -263,6 +272,8 @@ namespace MediaBrowser.Theater.Interfaces.Configuration
             LfeMixingLevel = 0;
             CenterMixingLevel = 0.7071;
             SurroundMixingLevel = 0.7071;
+            Renderer = AudioRendererChoice.Default;
+            AudioDevice = string.Empty;
         }
 
         public void SetDefaults()
@@ -295,14 +306,25 @@ namespace MediaBrowser.Theater.Interfaces.Configuration
         }
     }
 
+    #endregion
+
+    #region SubtitleConfig
+
     //add configuration values here as necessary
     public class SubtitleConfiguration
-    {   
+    {
         public List<string> ExternalExtensions { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether [enable xy sub filter].
+        /// </summary>
+        /// <value><c>true</c> if [enable xy sub filter]; otherwise, <c>false</c>.</value>
+        public bool EnableXySubFilter { get; set; }
 
         public SubtitleConfiguration()
         {
             ExternalExtensions = new List<string>();
+            EnableXySubFilter = true;
         }
 
         public void SetDefaults()
@@ -314,6 +336,10 @@ namespace MediaBrowser.Theater.Interfaces.Configuration
         }
     }
 
+    #endregion
+
+    #region KnownCOMObjects
+
     public class KnownCOMObjectConfiguration
     {
         private static Regex isGuid = new Regex(@"^(\{){0,1}[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}(\}){0,1}$", RegexOptions.Compiled);
@@ -323,21 +349,21 @@ namespace MediaBrowser.Theater.Interfaces.Configuration
             FilterList = new SerializableDictionary<Guid, KnownCOMObject>();
         }
 
-        public SerializableDictionary<Guid, KnownCOMObject> FilterList { get; set;}
+        public SerializableDictionary<Guid, KnownCOMObject> FilterList { get; set; }
 
         public void SetDefaults()
         {
-            if (FilterList.Count == 0)
-            {
-                //FilterList[new Guid("")] = new KnownFilter("", "", new Guid(""));
-                FilterList[new Guid("{171252A0-8820-4AFE-9DF8-5C92B2D66B04}")] = new KnownCOMObject("LAV Splitter", "LAV\\LAVSplitter.ax", new Guid("{171252A0-8820-4AFE-9DF8-5C92B2D66B04}"));
-                FilterList[new Guid("{B98D13E7-55DB-4385-A33D-09FD1BA26338}")] = new KnownCOMObject("LAV Splitter Source", "LAV\\LAVSplitter.ax", new Guid("{B98D13E7-55DB-4385-A33D-09FD1BA26338}"));
-                FilterList[new Guid("{E8E73B6B-4CB3-44A4-BE99-4F7BCB96E491}")] = new KnownCOMObject("LAV Audio Decoder", "LAV\\LAVAudio.ax", new Guid("{E8E73B6B-4CB3-44A4-BE99-4F7BCB96E491}"));
-                FilterList[new Guid("{EE30215D-164F-4A92-A4EB-9D4C13390F9F}")] = new KnownCOMObject("LAV Video Decoder", "LAV\\LAVVideo.ax", new Guid("{EE30215D-164F-4A92-A4EB-9D4C13390F9F}"));
-                FilterList[new Guid("{E1A8B82A-32CE-4B0D-BE0D-AA68C772E423}")] = new KnownCOMObject("madVR", "madVR\\madVR.ax", new Guid("{E1A8B82A-32CE-4B0D-BE0D-AA68C772E423}"));
-                FilterList[new Guid("{2DFCB782-EC20-4A7C-B530-4577ADB33F21}")] = new KnownCOMObject("XySubFilter", "XySubFilter\\XySubFilter.dll", new Guid("{2DFCB782-EC20-4A7C-B530-4577ADB33F21}"));
-                FilterList[new Guid("{5325DF1C-6F10-4292-B8FB-BE855F99F88A}")] = new KnownCOMObject("EVR Presenter (babgvant)", "babgvant\\EVRPresenter.dll", new Guid("{5325DF1C-6F10-4292-B8FB-BE855F99F88A}"));
-            }
+            FilterList.Clear();
+
+            //FilterList[new Guid("")] = new KnownCOMObject("", "", new Guid(""));
+            FilterList[new Guid("{171252A0-8820-4AFE-9DF8-5C92B2D66B04}")] = new KnownCOMObject("LAV Splitter", "LAV\\LAVSplitter.ax", new Guid("{171252A0-8820-4AFE-9DF8-5C92B2D66B04}"));
+            FilterList[new Guid("{B98D13E7-55DB-4385-A33D-09FD1BA26338}")] = new KnownCOMObject("LAV Splitter Source", "LAV\\LAVSplitter.ax", new Guid("{B98D13E7-55DB-4385-A33D-09FD1BA26338}"));
+            FilterList[new Guid("{E8E73B6B-4CB3-44A4-BE99-4F7BCB96E491}")] = new KnownCOMObject("LAV Audio Decoder", "LAV\\LAVAudio.ax", new Guid("{E8E73B6B-4CB3-44A4-BE99-4F7BCB96E491}"));
+            FilterList[new Guid("{EE30215D-164F-4A92-A4EB-9D4C13390F9F}")] = new KnownCOMObject("LAV Video Decoder", "LAV\\LAVVideo.ax", new Guid("{EE30215D-164F-4A92-A4EB-9D4C13390F9F}"));
+            FilterList[new Guid("{E1A8B82A-32CE-4B0D-BE0D-AA68C772E423}")] = new KnownCOMObject("madVR", "madVR\\madVR.ax", new Guid("{E1A8B82A-32CE-4B0D-BE0D-AA68C772E423}"));
+            FilterList[new Guid("{2DFCB782-EC20-4A7C-B530-4577ADB33F21}")] = new KnownCOMObject("XySubFilter", "XySubFilter\\XySubFilter.dll", new Guid("{2DFCB782-EC20-4A7C-B530-4577ADB33F21}"));
+            FilterList[new Guid("{5325DF1C-6F10-4292-B8FB-BE855F99F88A}")] = new KnownCOMObject("EVR Presenter (babgvant)", "babgvant\\EVRPresenter.dll", new Guid("{5325DF1C-6F10-4292-B8FB-BE855F99F88A}"));
+            FilterList[new Guid("{EC9ED6FC-7B03-4CB6-8C01-4EABE109F26B}")] = new KnownCOMObject("MP Audio Renderer", "mpaudio\\mpaudiorenderer.ax", new Guid("{EC9ED6FC-7B03-4CB6-8C01-4EABE109F26B}"));
         }
 
         public static bool IsGuid(string candidate, out Guid output)
@@ -377,4 +403,6 @@ namespace MediaBrowser.Theater.Interfaces.Configuration
 
 
     }
+
+    #endregion
 }


### PR DESCRIPTION
-If MP WASAPI audio is in the graph we don't have to remove it to do 4x+
FFWD so just mute audio
- Change around configuration objects to make more sense
