### PR TITLE
hide, don't disable scroll for media players page

### DIFF
--- a/MediaBrowser.Theater.Core/MediaPlayers/MediaPlayersPage.xaml
+++ b/MediaBrowser.Theater.Core/MediaPlayers/MediaPlayersPage.xaml
@@ -47,7 +47,7 @@
 
         <TextBlock Style="{StaticResource SmallTextBlockStyle}" Grid.Row="1">Configure custom media players to handle specific formats.</TextBlock>
 
-        <controls:ExtendedListBox Margin="-40 0 -40 -35" HorizontalAlignment="Stretch" Grid.Row="2" x:Name="LstItems" ScrollViewer.HorizontalScrollBarVisibility="Disabled" ScrollViewer.VerticalScrollBarVisibility="Disabled" Style="{StaticResource ListBoxStyle}" ItemContainerStyle="{StaticResource HighlightedBorderListBoxItemStyle}" ScrollViewer.CanContentScroll="False" ItemTemplate="{StaticResource MediaPlayersListBoxItemTemplate}">
+        <controls:ExtendedListBox Margin="-40 0 -40 -35" HorizontalAlignment="Stretch" Grid.Row="2" x:Name="LstItems" ScrollViewer.HorizontalScrollBarVisibility="Disabled" ScrollViewer.VerticalScrollBarVisibility="Hidden" Style="{StaticResource ListBoxStyle}" ItemContainerStyle="{StaticResource HighlightedBorderListBoxItemStyle}" ScrollViewer.CanContentScroll="False" ItemTemplate="{StaticResource MediaPlayersListBoxItemTemplate}">
             <controls:ExtendedListBox.ItemsPanel>
                 <ItemsPanelTemplate>
                     <StackPanel Margin="40 35" Orientation="Vertical"></StackPanel>


### PR DESCRIPTION
ScrollViewer.VerticalScrollBarVisibility=Disabled means scrolling isn't
allowed at all. It should be Hidden instead to ensure that users can
still see past the first few entries if they have many external media
players configured (ex. using GameBrowser or MB Bookshelf)
